### PR TITLE
Change willBePresented callback to use a block.

### DIFF
--- a/FSQRoutes/FSQUrlRouter.h
+++ b/FSQRoutes/FSQUrlRouter.h
@@ -148,7 +148,20 @@ typedef NS_ENUM(NSInteger, FSQUrlRoutingControl) {
 
 - (UIViewController *)urlRouter:(FSQUrlRouter *)urlRouter viewControllerToPresentRoutedUrlFrom:(FSQRouteContent *)routeContent;
 
-- (void)urlRouter:(FSQUrlRouter *)urlRouter routedUrlWillBePresented:(FSQRouteContent *)routeContent;
+/**
+ This delegate method will get called whenever a routed url is about to go on screen.
+ 
+ !! You MUST call the completion handler or your route will get dropped !!
+ 
+ You can use this callback to do any setup that is needed before the route is presented (eg dismiss existing modals)
+ 
+ @param urlRouter         The router about to present the route
+ @param routeContent      The route content that is going to be presented
+ @param completionHandler A completion handler that you must call when any work you need to do is finished. 
+ Execution of this block does the actual presentation asynchronously on the main thread.
+
+ */
+- (void)urlRouter:(FSQUrlRouter *)urlRouter routedUrlWillBePresented:(FSQRouteContent *)routeContent completionHandler:(void (^)())completionHandler;
 - (void)urlRouter:(FSQUrlRouter *)urlRouter routedUrlDidGetPresented:(FSQRouteContent *)routeContent;
 
 - (void)urlRouter:(FSQUrlRouter *)urlRouter failedToRouteUrl:(NSURL *)url notificationUserInfo:(nullable NSDictionary *)notificationUserInfo;

--- a/FSQRoutes/FSQUrlRouter.m
+++ b/FSQRoutes/FSQUrlRouter.m
@@ -780,9 +780,17 @@ typedef NS_ENUM(NSInteger, FSQRouteUrlTokenType) {
             UIViewController *viewController = [self.delegate urlRouter:self viewControllerToPresentRoutedUrlFrom:routeContent];
 
             if (viewController != nil) {
-                [self.delegate urlRouter:self routedUrlWillBePresented:routeContent];
-                [routeContent presentFromViewController:viewController];
-                [self.delegate urlRouter:self routedUrlDidGetPresented:routeContent];
+                void (^delegateCompletionBlock)() = ^() {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [routeContent presentFromViewController:viewController];
+                        [self.delegate urlRouter:self routedUrlDidGetPresented:routeContent];                        
+                    });
+                };
+                
+                [self.delegate urlRouter:self
+                routedUrlWillBePresented:routeContent
+                       completionHandler:delegateCompletionBlock];
+
             }
 
         }


### PR DESCRIPTION
You must now fire the block yourself in the callback, but you can do so asynchronously (Eg after you finish dismissing existing views)
