### PR TITLE
Fix route presentation when delegate changes view hierarchy

### DIFF
--- a/FSQRoutes/FSQUrlRouter.h
+++ b/FSQRoutes/FSQUrlRouter.h
@@ -257,14 +257,16 @@ typedef NS_ENUM(NSInteger, FSQUrlRoutingControl) {
  This method is called when routed content is being presented. 
  
  FSQRouteContent objects must have a view controller that they are presented from (so that they can push views 
- onto the stack, etc.). 
+ onto the stack, etc.).
+ 
+ !! When urlRouter:shouldPresentRoute: returns FSQUrlRouterAllowRouting, this must NOT return nil.
  
  @param urlRouter    The url router presenting route content.
  @param routeContent The content object being presented.
  
  @return The view controller the route content object should be presented from.
  */
-- (UIViewController *)urlRouter:(FSQUrlRouter *)urlRouter viewControllerToPresentRoutedUrlFrom:(FSQRouteContent *)routeContent;
+- (nullable UIViewController *)urlRouter:(FSQUrlRouter *)urlRouter viewControllerToPresentRoutedUrlFrom:(FSQRouteContent *)routeContent;
 
 /**
  This method is called whenever a routed url is about to be presented.

--- a/FSQRoutes/FSQUrlRouter.m
+++ b/FSQRoutes/FSQUrlRouter.m
@@ -777,22 +777,20 @@ typedef NS_ENUM(NSInteger, FSQRouteUrlTokenType) {
     
     switch (routingControl) {
         case FSQUrlRouterAllowRouting: {
-            UIViewController *viewController = [self.delegate urlRouter:self viewControllerToPresentRoutedUrlFrom:routeContent];
-
-            if (viewController != nil) {
-                void (^delegateCompletionBlock)() = ^() {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [routeContent presentFromViewController:viewController];
-                        [self.delegate urlRouter:self routedUrlDidGetPresented:routeContent];                        
-                    });
-                };
-                
-                [self.delegate urlRouter:self
-                routedUrlWillBePresented:routeContent
-                       completionHandler:delegateCompletionBlock];
-
-            }
-
+            void (^delegateCompletionBlock)() = ^() {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    UIViewController *presentingViewController = [self.delegate urlRouter:self
+                                                     viewControllerToPresentRoutedUrlFrom:routeContent];
+                    if (presentingViewController) {
+                        [routeContent presentFromViewController:presentingViewController];
+                        [self.delegate urlRouter:self routedUrlDidGetPresented:routeContent];
+                    }
+                });
+            };
+            
+            [self.delegate urlRouter:self
+            routedUrlWillBePresented:routeContent
+                   completionHandler:delegateCompletionBlock];
         }
             break;
         case FSQUrlRouterCancelRouting: {


### PR DESCRIPTION
This fixes a bug where a route would not be presented because our delegate's implementation of urlRouter:routedUrlWillBePresented:completionHandler: modified the view hierarchy to remove the view controller returned by urlRouter:viewControllerToPresentRoutedUrlFrom:.

This introduces the condition warned of in the interface comment: if urlRouter:viewControllerToPresentRoutedUrlFrom: returns nil, and urlRouter:shouldPresentRoute: returns FSQUrlRouterAllowRouting, the WillBePresented delegate would get called but the route and DidPresent won't get called. I am ok with this being documented undefined behavior.